### PR TITLE
Fix incorrect token names for erc721 and erc1155 tokens

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http.ex
@@ -165,11 +165,11 @@ defmodule EthereumJSONRPC.HTTP do
 
   # restrict response to only those fields supported by the JSON-RPC 2.0 standard, which means that level of keys is
   # validated, so we can indicate that with switch to atom keys.
-  def standardize_response(%{"jsonrpc" => "2.0" = jsonrpc, "id" => id} = unstandardized) do
+  def standardize_response(%{"id" => id} = unstandardized) do
     # Nethermind return string ids
     id = quantity_to_integer(id)
 
-    standardized = %{jsonrpc: jsonrpc, id: id}
+    standardized = %{jsonrpc: "2.0", id: id}
 
     case {id, unstandardized} do
       {_id, %{"result" => _, "error" => _}} ->

--- a/apps/indexer/lib/indexer/block/catchup/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/catchup/fetcher.ex
@@ -13,6 +13,7 @@ defmodule Indexer.Block.Catchup.Fetcher do
       async_import_block_rewards: 1,
       async_import_coin_balances: 2,
       async_import_created_contract_codes: 1,
+      async_import_internal_transactions: 1,
       async_import_replaced_transactions: 1,
       async_import_tokens: 1,
       async_import_token_balances: 1,
@@ -158,6 +159,7 @@ defmodule Indexer.Block.Catchup.Fetcher do
     async_import_block_rewards(block_reward_errors)
     async_import_coin_balances(imported, options)
     async_import_created_contract_codes(imported)
+    async_import_internal_transactions(imported)
     async_import_tokens(imported)
     async_import_token_balances(imported)
     async_import_uncles(imported)

--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -17,6 +17,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
       async_import_blobs: 1,
       async_import_block_rewards: 1,
       async_import_created_contract_codes: 1,
+      async_import_internal_transactions: 1,
       async_import_replaced_transactions: 1,
       async_import_tokens: 1,
       async_import_token_balances: 1,
@@ -448,6 +449,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
     async_import_realtime_coin_balances(imported)
     async_import_block_rewards(block_reward_errors)
     async_import_created_contract_codes(imported)
+    async_import_internal_transactions(imported)
     async_import_tokens(imported)
     async_import_token_balances(imported)
     async_import_token_instances(imported)

--- a/apps/indexer/lib/indexer/supervisor.ex
+++ b/apps/indexer/lib/indexer/supervisor.ex
@@ -74,7 +74,6 @@ defmodule Indexer.Supervisor do
     Supervisor.start_link(__MODULE__, arguments, Keyword.put_new(gen_server_options, :name, __MODULE__))
   end
 
-  #TODO: Add internal transactions and pending transactions supervisors
   @impl Supervisor
   def init(%{memory_monitor: memory_monitor}) do
     json_rpc_named_arguments = Application.fetch_env!(:indexer, :json_rpc_named_arguments)
@@ -111,6 +110,8 @@ defmodule Indexer.Supervisor do
 
     basic_fetchers =
       [
+        # Root fetchers
+        {PendingTransaction.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments]]},
         # Async catchup fetchers
         {UncleBlock.Supervisor, [[block_fetcher: block_fetcher, memory_monitor: memory_monitor]]},
         {BlockReward.Supervisor,


### PR DESCRIPTION
- Moves the indexer app to its original state.
- Fixes incorrect rendering of token names for ERC721 and ERC1155 by adding handling for responses without the JSON-RPC version (temporary solution until the bug in skaled is fixed)